### PR TITLE
node@v6.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM resin/rpi-raspbian:jessie-20170331
 
 MAINTAINER Global-solutions
 
-ENV NODE_VERSION=6.10.1 \
+ENV NODE_VERSION=6.10.2 \
     ARCH=armv7l
 
 RUN DEPS="ca-certificates curl" && \


### PR DESCRIPTION
## What

* gsol/rpi-node:6.10.2-armv7l
  * resin/rpi-raspbian:jessie-20170331
  * node: node-v6.10.2-linux-armv7l