### PR TITLE
bump(Dockerfile): base image ver.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:jessie-20170719
+FROM resin/rpi-raspbian:jessie-20180801
 
 MAINTAINER Global-solutions
 


### PR DESCRIPTION
* gsol/rpi-node:6.11.1-armv7l-r2
  * resin/rpi-raspbian:jessie-20180801